### PR TITLE
Test/chat

### DIFF
--- a/src/main/java/com/banduu/conversacion/controladores/ControladorMensajes.java
+++ b/src/main/java/com/banduu/conversacion/controladores/ControladorMensajes.java
@@ -11,6 +11,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,6 +24,7 @@ import java.util.List;
  * @version 1.0
  */
 @Controller
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class ControladorMensajes {
 

--- a/src/test/java/com/banduu/conversacion/controladores/ControladorMensajesTest.java
+++ b/src/test/java/com/banduu/conversacion/controladores/ControladorMensajesTest.java
@@ -1,0 +1,170 @@
+package com.banduu.conversacion.controladores;
+
+import com.banduu.conversacion.modelos.Mensaje;
+import com.banduu.conversacion.servicios.ServicioMensaje;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+class ControladorMensajesTest {
+    
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @Autowired
+    private ServicioMensaje servicioMensaje;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @Autowired
+    private com.banduu.conversacion.repositorios.RepositorioConversacion repositorioConversacion;
+    
+    @Autowired
+    private com.banduu.conversacion.repositorios.RepositorioMensaje repositorioMensaje;
+
+    @BeforeEach
+    void setUp() {
+        repositorioMensaje.deleteAll();
+        repositorioConversacion.deleteAll();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        repositorioMensaje.deleteAll();
+        repositorioConversacion.deleteAll();
+    }
+
+    @Test
+    void testObtenerMensajesConversacionExistente() throws Exception {
+        Mensaje mensaje1 = Mensaje.builder()
+                .idRemitente("usuario1")
+                .idDestinatario("usuario2")
+                .contenido("Hola usuario2")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        Mensaje mensaje2 = Mensaje.builder()
+                .idRemitente("usuario2")
+                .idDestinatario("usuario1")
+                .contenido("Hola usuario1")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        servicioMensaje.save(mensaje1);
+        servicioMensaje.save(mensaje2);
+
+        mockMvc.perform(get("/api/mensajes/usuario1/usuario2")
+                .header("Authorization", "no Auth"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].idRemitente").exists())
+                .andExpect(jsonPath("$[0].idDestinatario").exists())
+                .andExpect(jsonPath("$[0].contenido").exists());
+    }
+
+    @Test
+    void testObtenerMensajesConversacionInexistente() throws Exception {
+        mockMvc.perform(get("/api/mensajes/usuarioInexistente1/usuarioInexistente2")
+                .header("Authorization", "no Auth"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void testObtenerMensajesConParametrosVacios() throws Exception {
+        mockMvc.perform(get("/api/mensajes/ / ")
+                .header("Authorization", "no Auth"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void testObtenerMensajesConUsuariosMismos() throws Exception {
+        Mensaje mensaje = Mensaje.builder()
+                .idRemitente("usuario1")
+                .idDestinatario("usuario1")
+                .contenido("Mensaje a mí mismo")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        servicioMensaje.save(mensaje);
+
+        mockMvc.perform(get("/api/mensajes/usuario1/usuario1")
+                .header("Authorization", "no Auth"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].contenido").value("Mensaje a mí mismo"));
+    }
+
+    @Test
+    void testObtenerMensajesConUsuariosInvertidos() throws Exception {
+        Mensaje mensaje1 = Mensaje.builder()
+                .idRemitente("usuario1")
+                .idDestinatario("usuario2")
+                .contenido("De usuario1 a usuario2")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        servicioMensaje.save(mensaje1);
+
+        mockMvc.perform(get("/api/mensajes/usuario2/usuario1")
+                .header("Authorization", "no Auth"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].contenido").value("De usuario1 a usuario2"));
+    }
+
+    @Test
+    void testObtenerMensajesRespuestaFormatoCorrect() throws Exception {
+        Mensaje mensaje = Mensaje.builder()
+                .idRemitente("usuario1")
+                .idDestinatario("usuario2")
+                .contenido("Mensaje de prueba")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        servicioMensaje.save(mensaje);
+
+        mockMvc.perform(get("/api/mensajes/usuario1/usuario2")
+                .header("Authorization", "no Auth"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$[0].id").exists())
+                .andExpect(jsonPath("$[0].idRemitente").value("usuario1"))
+                .andExpect(jsonPath("$[0].idDestinatario").value("usuario2"))
+                .andExpect(jsonPath("$[0].contenido").value("Mensaje de prueba"))
+                .andExpect(jsonPath("$[0].fechaEnvio").exists())
+                .andExpect(jsonPath("$[0].leido").exists())
+                .andExpect(jsonPath("$[0].conversacionId").exists());
+    }
+}

--- a/src/test/java/com/banduu/conversacion/servicios/ServicioConversacionTest.java
+++ b/src/test/java/com/banduu/conversacion/servicios/ServicioConversacionTest.java
@@ -1,0 +1,57 @@
+package com.banduu.conversacion.servicios;
+
+import com.banduu.conversacion.repositorios.RepositorioConversacion;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ServicioConversacionTest {
+    
+    @Autowired
+    private ServicioConversacion servicioConversacion;
+    
+    @Autowired
+    private RepositorioConversacion repositorioConversacion;
+
+    @AfterEach
+    void limpiarDatos() {
+        repositorioConversacion.deleteAll();
+    }
+
+    @Test
+    void testObtenerIdConversacionCreandoSiNoExiste() {
+        Optional<String> idConversacion = servicioConversacion.obtenerIdConversacion("usuario1", "usuario2", true);
+
+        assertTrue(idConversacion.isPresent());
+        assertNotNull(idConversacion.get());
+        assertTrue(idConversacion.get().contains("usuario1"));
+        assertTrue(idConversacion.get().contains("usuario2"));
+    }
+
+    @Test
+    void testObtenerIdConversacionExistente() {
+        Optional<String> idConversacionCreada = servicioConversacion.obtenerIdConversacion("usuario1", "usuario2", true);
+        assertTrue(idConversacionCreada.isPresent());
+
+        Optional<String> idConversacionObtenida = servicioConversacion.obtenerIdConversacion("usuario1", "usuario2", false);
+
+        assertTrue(idConversacionObtenida.isPresent());
+        assertEquals(idConversacionCreada.get(), idConversacionObtenida.get());
+    }
+
+    @Test
+    void testFormatoIdConversacionOrdenInvertido() {
+        Optional<String> idConversacion = servicioConversacion.obtenerIdConversacion("zzz", "aaa", true);
+
+        assertTrue(idConversacion.isPresent());
+        assertEquals("aaa-zzz", idConversacion.get());
+    }
+}

--- a/src/test/java/com/banduu/conversacion/servicios/ServicioMensajeTest.java
+++ b/src/test/java/com/banduu/conversacion/servicios/ServicioMensajeTest.java
@@ -1,0 +1,139 @@
+package com.banduu.conversacion.servicios;
+
+import com.banduu.conversacion.modelos.Mensaje;
+import com.banduu.conversacion.repositorios.RepositorioMensaje;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ServicioMensajeTest {
+    
+    @Autowired
+    private ServicioMensaje servicioMensaje;
+    
+    @Autowired
+    private RepositorioMensaje repositorioMensaje;
+
+    @Autowired
+    private com.banduu.conversacion.repositorios.RepositorioConversacion repositorioConversacion;
+
+    @AfterEach
+    void limpiarDatos() {
+        repositorioMensaje.deleteAll();
+        repositorioConversacion.deleteAll();
+    }
+
+    @Test
+    void testGuardarMensaje() {
+        Mensaje mensaje = Mensaje.builder()
+                .idRemitente("usuario1")
+                .idDestinatario("usuario2")
+                .contenido("Hola, ¿cómo estas?")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        Mensaje mensajeGuardado = servicioMensaje.save(mensaje);
+
+        assertNotNull(mensajeGuardado);
+        assertNotNull(mensajeGuardado.getConversacionId());
+        assertEquals("usuario1", mensajeGuardado.getIdRemitente());
+        assertEquals("usuario2", mensajeGuardado.getIdDestinatario());
+        assertEquals("Hola, ¿cómo estas?", mensajeGuardado.getContenido());
+        assertFalse(mensajeGuardado.isLeido());
+    }
+
+    @Test
+    void testObtenerMensajesConversacionExistente() {
+        Mensaje mensaje1 = Mensaje.builder()
+                .idRemitente("usuario1")
+                .idDestinatario("usuario2")
+                .contenido("Primer mensaje")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        Mensaje mensaje2 = Mensaje.builder()
+                .idRemitente("usuario2")
+                .idDestinatario("usuario1")
+                .contenido("Respuesta al primer mensaje")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        servicioMensaje.save(mensaje1);
+        servicioMensaje.save(mensaje2);
+
+        List<Mensaje> mensajes = servicioMensaje.obtenerMensajes("usuario1", "usuario2");
+
+        assertEquals(2, mensajes.size());
+        assertTrue(mensajes.stream().anyMatch(m -> m.getContenido().equals("Primer mensaje")));
+        assertTrue(mensajes.stream().anyMatch(m -> m.getContenido().equals("Respuesta al primer mensaje")));
+    }
+
+    @Test
+    void testObtenerMensajesConversacionInexistente() {
+        List<Mensaje> mensajes = servicioMensaje.obtenerMensajes("usuarioInexistente1", "usuarioInexistente2");
+
+        assertTrue(mensajes.isEmpty());
+    }
+
+    @Test
+    void testGuardarMensajeConMismaConversacion() {
+        Mensaje mensaje1 = Mensaje.builder()
+                .idRemitente("usuario1")
+                .idDestinatario("usuario2")
+                .contenido("Primer mensaje")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        Mensaje mensaje2 = Mensaje.builder()
+                .idRemitente("usuario1")
+                .idDestinatario("usuario2")
+                .contenido("Segundo mensaje")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        Mensaje mensajeGuardado1 = servicioMensaje.save(mensaje1);
+        Mensaje mensajeGuardado2 = servicioMensaje.save(mensaje2);
+
+        assertNotNull(mensajeGuardado1.getConversacionId());
+        assertNotNull(mensajeGuardado2.getConversacionId());
+        assertEquals(mensajeGuardado1.getConversacionId(), mensajeGuardado2.getConversacionId());
+    }
+
+    @Test
+    void testGuardarMensajeConUsuariosInvertidos() {
+        Mensaje mensaje1 = Mensaje.builder()
+                .idRemitente("usuario1")
+                .idDestinatario("usuario2")
+                .contenido("Mensaje de usuario1 a usuario2")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        Mensaje mensaje2 = Mensaje.builder()
+                .idRemitente("usuario2")
+                .idDestinatario("usuario1")
+                .contenido("Respuesta de usuario2 a usuario1")
+                .fechaEnvio(LocalDateTime.now())
+                .leido(false)
+                .build();
+
+        Mensaje mensajeGuardado1 = servicioMensaje.save(mensaje1);
+        Mensaje mensajeGuardado2 = servicioMensaje.save(mensaje2);
+
+        assertEquals(mensajeGuardado1.getConversacionId(), mensajeGuardado2.getConversacionId());
+    }
+}


### PR DESCRIPTION
This pull request introduces a new endpoint structure for the `ControladorMensajes` class and significantly expands the test coverage for the messaging and conversation services. The most important changes include adding a base API path to the controller, creating comprehensive test classes for `ControladorMensajes`, `ServicioConversacion`, and `ServicioMensaje`, and ensuring proper data setup and cleanup in tests.

### Controller Changes:
* Added `@RequestMapping("/api")` to the `ControladorMensajes` class to define a base API path for all endpoints in this controller. (`[[1]](diffhunk://#diff-6a6bc1cd000f4e6c6b48cccd9dd886d67994f9227700d6a7a96f6d750daf8dacR14)`, `[[2]](diffhunk://#diff-6a6bc1cd000f4e6c6b48cccd9dd886d67994f9227700d6a7a96f6d750daf8dacR27)`)

### Test Coverage Enhancements:
#### `ControladorMensajesTest`:
* Introduced a new test class `ControladorMensajesTest` with multiple test cases to validate the behavior of the `ControladorMensajes` endpoints, including scenarios for existing conversations, non-existent conversations, empty parameters, and reversed user roles. (`[src/test/java/com/banduu/conversacion/controladores/ControladorMensajesTest.javaR1-R170](diffhunk://#diff-934f5267135989d49abcbebd8e6e3c90380c57b08d2e738ea14ca954a5a0ebe1R1-R170)`)

#### `ServicioConversacionTest`:
* Added `ServicioConversacionTest` to test the `obtenerIdConversacion` method, ensuring correct behavior for creating new conversations, retrieving existing ones, and handling inverted user order. (`[src/test/java/com/banduu/conversacion/servicios/ServicioConversacionTest.javaR1-R57](diffhunk://#diff-71b2b3f065727537f6464273a8021ef446a9c14fdb752716e6d8171358ec5af2R1-R57)`)

#### `ServicioMensajeTest`:
* Created `ServicioMensajeTest` to test the `ServicioMensaje` class, covering scenarios like saving messages, retrieving messages for existing and non-existing conversations, and verifying consistent conversation IDs for related messages. (`[src/test/java/com/banduu/conversacion/servicios/ServicioMensajeTest.javaR1-R139](diffhunk://#diff-8067b0a44e4ab2a802c2c2a614656e438f6cda77092d71dfcdc3910feeae8545R1-R139)`)